### PR TITLE
Fix Blue Sky effect text

### DIFF
--- a/src/assets/knowledges.json
+++ b/src/assets/knowledges.json
@@ -15,7 +15,7 @@
     "name": "Blue Sky",
     "type": "spell",
     "cost": 2,
-    "effect": "Gain [1, 2, 3] power point, according rotation.",
+    "effect": "Gain [1, 2, 3] power points, according to rotation.",
     "image": "/images/spells/aerial2.jpg",
     "maxRotations": 3,
     "element": "air"


### PR DESCRIPTION
## Summary
- correct a typo in Blue Sky card description

## Testing
- `npx vitest run` *(fails: failed to resolve `extends: "expo/tsconfig.base"` in tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849a6b46d88832aaeee3a003010a1bb